### PR TITLE
Fixed a typo at `Message::from_arc()`

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -141,7 +141,7 @@ impl Message {
     /// use std::sync::Arc;
     ///
     /// let arc = Arc::new(11);
-    /// let msg = Message::new(arc);
+    /// let msg = Message::from_arc(arc);
     /// ```
     pub fn from_arc<T>(value: Arc<T>) -> Message
     where


### PR DESCRIPTION
I think it should be `..::from_arc(arc)` rather than `..::new(arc)`.